### PR TITLE
Hyperlink DOIs to recommended resolver

### DIFF
--- a/c++/src/objtools/format/reference_item.cpp
+++ b/c++/src/objtools/format/reference_item.cpp
@@ -1418,7 +1418,7 @@ DEFINE_STATIC_ARRAY_MAP(TStaticRemarkSet, sc_Remarks, sc_RemarkText);
 
 void CReferenceItem::x_GatherRemark(CBioseqContext& ctx)
 {
-    static const char* const kDoiLink = "http://dx.doi.org/";
+    static const char* const kDoiLink = "https://doi.org/";
 
     list<string> l;
 


### PR DESCRIPTION
Hello :-)

The DOI Foundation [started recommending a new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). While their URL change may be a bit ironic, it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old `dx` subdomain is being redirected. So, there is no urgency here.

However, for consistency, this PRs suggests to update the code that generates new DOI links.

Cheers!